### PR TITLE
Fix for Column.Asc()

### DIFF
--- a/pgmini/order_by.py
+++ b/pgmini/order_by.py
@@ -18,7 +18,7 @@ class OrderByMX:
         if self._marks:
             marks = attrs.evolve(self._marks, order_by='ASC')
         else:
-            marks = Marks(order_by='DESC')
+            marks = Marks(order_by='ASC')
         return attrs.evolve(self, x_marks=marks)
 
     def NullsFirst(self):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -260,6 +260,11 @@ def test_order_by_desc():
     assert build(S(L(1)).From(t).OrderBy(t.id.Desc()))[0] == 'SELECT 1 FROM t ORDER BY id DESC'
 
 
+def test_order_by_asc():
+    assert build(S(L(1)).From(t).OrderBy(t.id.Asc()))[0] == 'SELECT 1 FROM t ORDER BY id ASC'
+
+
+
 def test_order_by_nulls_last():
     assert (
         build(S(L(1)).From(t).OrderBy(t.id.NullsLast()))[0]


### PR DESCRIPTION
Fixes issue #1 where Column.Asc() gets marked with order_by='DESC'.